### PR TITLE
Drop Python versions <3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
-          - "pypy-3.8"
           - "pypy-3.9"
           - "pypy-3.10"
 
@@ -42,7 +39,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - run: python -Im pip install --upgrade wheel tox
+          cache: pip
+      - run: python -Im pip install tox
 
       - name: Determine Python version for tox
         run: |
@@ -65,16 +63,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          cache: pip
           python-version-file: .python-version-default
+          cache: pip
 
       - name: Install dependencies
         run: |
           sudo apt-get install libargon2-0 libargon2-0-dev
           # Ensure we cannot use our own Argon2 by accident.
           rm -rf extras
-      - run: python -Im pip install --upgrade wheel tox
-      - run: python -Im tox -e system-argon2
+      - run: python -Im pip install tox
+      - run: python -Im tox run -e system-argon2
 
   package:
     name: Build & verify package
@@ -114,6 +112,7 @@ jobs:
           cache: pip
           python-version-file: .python-version-default
       - run: python -Im pip install -e .[dev]
+
       - name: Import package
         run: python -c 'from _argon2_cffi_bindings import ffi, lib; print(lib.ARGON2_VERSION_NUMBER)'
       - run: otool -L src/_argon2_cffi_bindings/_ffi.abi3.so
@@ -133,9 +132,9 @@ jobs:
           cache: pip
           python-version: "3.x"
 
-      - run: python -Im pip install --upgrade wheel tox
+      - run: python -Im pip install tox
 
-      - run: python -Im tox -e cog-check
+      - run: python -Im tox run -e cog-check
 
   required-checks-pass:
     name: Ensure everything required is passing for branch protection

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,13 +38,11 @@ jobs:
 
       - uses: pypa/cibuildwheel@v2.19.2
         env:
-          # Only build CPython 3.7, because we have portable abi3 wheels.
-          # Windows arm64 is only available on 3.9 and later, Apple Silicon on
-          # 3.8 and later.
-          CIBW_BUILD: "cp37-* pp37-* pp38-* cp39-win_arm64 cp38-macosx_universal2"
+          # Only build CPython 3.9, because we have portable abi3 wheels.
+          CIBW_BUILD: "cp39-* cp39-win_arm64"
           CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_ARCHS_MACOS: "auto universal2"
-          CIBW_TEST_COMMAND: python -c "from _argon2_cffi_bindings import ffi, lib; print(lib.ARGON2_VERSION_NUMBER)"
+          CIBW_TEST_COMMAND: python -Ic "from _argon2_cffi_bindings import ffi, lib; print(lib.ARGON2_VERSION_NUMBER)"
           # https://github.com/pypa/cibuildwheel/pull/1169
           CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,15 @@ Vendoring Argon2 @ [**`f57e61e`**](https://github.com/P-H-C/phc-winner-argon2/co
 
 ### Added
 
-- Official Python 3.12 support.
+- Official Python 3.12 and 3.13 support.
   No code or packaging changes were necessary.
 
 
 ### Removed
 
-- Python 3.6 support.
+- Python 3.6, 3.7, and 3.8 support.
+  There is very little activity on the bindings repo, so it doesn't make sense to carry around the build complexity of those ancient Python versions.
+  The [21.2.0 wheels on PyPI](https://pypi.org/project/argon2-cffi-bindings/21.2.0/) include support for Python 3.6 and are based on the same Argon2 version.
 
 
 ## [21.2.0](https://github.com/hynek/argon2-cffi-bindings/compare/21.1.0...21.2.0) - 2021-12-01

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=45",
     "setuptools_scm[toml]>=6.2",
-    "wheel",
     "cffi>=1.0.1",
 ]
 build-backend = "setuptools.build_meta"
@@ -14,7 +13,7 @@ name = "argon2-cffi-bindings"
 description = "Low-level CFFI bindings for Argon2"
 readme = { content-type = "text/markdown", file = "README.md" }
 authors = [{ name = "Hynek Schlawack", email = "hs@ox.cx" }]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 # Setuptools doesn't support PEP 639, yet.
 license = { text = "MIT" }
 keywords = ["password", "hash", "hashing", "security", "bindings", "cffi"]
@@ -27,8 +26,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Operating System :: Unix",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
They make builds unnecessarily complicated and the old wheels that go back to 3.6 exist.