### PR TITLE
Add arm64 wheel build for Windows

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         # macOS-13 is Intel, macOS-14 is ARM
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macOS-13, macOS-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, windows-11-arm, macOS-13, macOS-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,6 @@ jobs:
         env:
           # Only build CPython 3.9, because we have portable abi3 wheels.
           CIBW_BUILD: "cp39-*"
-          CIBW_ARCHS_WINDOWS: "auto ARM64"
           CIBW_ARCHS_LINUX: "auto"
           CIBW_ARCHS_MACOS: "auto universal2"
           CIBW_TEST_COMMAND: python -Ic "from _argon2_cffi_bindings import ffi, lib; print(lib.ARGON2_VERSION_NUMBER)"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         # macOS-13 is Intel, macOS-14 is ARM
-        os: [ubuntu-20.04, ubuntu-22.04-arm, windows-2019, macOS-13, macOS-14]
+        os: [ubuntu-20.04, ubuntu-22.04-arm, windows-2022, macOS-13, macOS-14]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +41,8 @@ jobs:
       - uses: pypa/cibuildwheel@v2.23
         env:
           # Only build CPython 3.9, because we have portable abi3 wheels.
-          CIBW_BUILD: "cp39-* cp39-win_arm64"
+          CIBW_BUILD: "cp313-win_arm64 cp39-*"
+          CIBW_ARCHS_WINDOWS: "auto ARM64"
           CIBW_ARCHS_LINUX: "auto"
           CIBW_ARCHS_MACOS: "auto universal2"
           CIBW_TEST_COMMAND: python -Ic "from _argon2_cffi_bindings import ffi, lib; print(lib.ARGON2_VERSION_NUMBER)"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: pypa/cibuildwheel@v2.23
         env:
           # Only build CPython 3.9, because we have portable abi3 wheels.
-          CIBW_BUILD: "cp313-win_arm64 cp39-*"
+          CIBW_BUILD: "cp39-*"
           CIBW_ARCHS_WINDOWS: "auto ARM64"
           CIBW_ARCHS_LINUX: "auto"
           CIBW_ARCHS_MACOS: "auto universal2"

--- a/src/_argon2_cffi_bindings/_ffi_build.py
+++ b/src/_argon2_cffi_bindings/_ffi_build.py
@@ -14,7 +14,7 @@ windows = platform.system() == "Windows"
 
 
 # Try to detect cross-compilation.
-def _get_target_platform(arch_flags, default, vscmd_target_arch = ""):
+def _get_target_platform(arch_flags, default, vscmd_target_arch=""):
     if vscmd_target_arch != "":
         return vscmd_target_arch
     flags = [f for f in arch_flags.split(" ") if f.strip() != ""]
@@ -29,7 +29,9 @@ def _get_target_platform(arch_flags, default, vscmd_target_arch = ""):
 
 
 target_platform = _get_target_platform(
-    os.environ.get("ARCHFLAGS", ""), platform.machine(), os.environ.get("VSCMD_ARG_TGT_ARCH", "")
+    os.environ.get("ARCHFLAGS", ""),
+    platform.machine(),
+    os.environ.get("VSCMD_ARG_TGT_ARCH", ""),
 )
 
 

--- a/src/_argon2_cffi_bindings/_ffi_build.py
+++ b/src/_argon2_cffi_bindings/_ffi_build.py
@@ -14,9 +14,9 @@ windows = platform.system() == "Windows"
 
 
 # Try to detect cross-compilation.
-def _get_target_platform(tgt_arch, arch_flags, default):
-    if tgt_arch != "":
-        return tgt_arch
+def _get_target_platform(arch_flags, default, vscmd_target_arch = ""):
+    if vscmd_target_arch != "":
+        return vscmd_target_arch
     flags = [f for f in arch_flags.split(" ") if f.strip() != ""]
     try:
         pos = flags.index("-arch")
@@ -29,7 +29,7 @@ def _get_target_platform(tgt_arch, arch_flags, default):
 
 
 target_platform = _get_target_platform(
-    os.environ.get("VSCMD_ARG_TGT_ARCH", ""), os.environ.get("ARCHFLAGS", ""), platform.machine()
+    os.environ.get("ARCHFLAGS", ""), platform.machine(), os.environ.get("VSCMD_ARG_TGT_ARCH", "")
 )
 
 

--- a/src/_argon2_cffi_bindings/_ffi_build.py
+++ b/src/_argon2_cffi_bindings/_ffi_build.py
@@ -14,9 +14,7 @@ windows = platform.system() == "Windows"
 
 
 # Try to detect cross-compilation.
-def _get_target_platform(arch_flags, default, vscmd_target_arch=""):
-    if vscmd_target_arch != "":
-        return vscmd_target_arch
+def _get_target_platform(arch_flags, default):
     flags = [f for f in arch_flags.split(" ") if f.strip() != ""]
     try:
         pos = flags.index("-arch")
@@ -29,9 +27,7 @@ def _get_target_platform(arch_flags, default, vscmd_target_arch=""):
 
 
 target_platform = _get_target_platform(
-    os.environ.get("ARCHFLAGS", ""),
-    platform.machine(),
-    os.environ.get("VSCMD_ARG_TGT_ARCH", ""),
+    os.environ.get("ARCHFLAGS", ""), platform.machine()
 )
 
 

--- a/src/_argon2_cffi_bindings/_ffi_build.py
+++ b/src/_argon2_cffi_bindings/_ffi_build.py
@@ -14,7 +14,9 @@ windows = platform.system() == "Windows"
 
 
 # Try to detect cross-compilation.
-def _get_target_platform(arch_flags, default):
+def _get_target_platform(tgt_arch, arch_flags, default):
+    if tgt_arch != "":
+        return tgt_arch
     flags = [f for f in arch_flags.split(" ") if f.strip() != ""]
     try:
         pos = flags.index("-arch")
@@ -27,7 +29,7 @@ def _get_target_platform(arch_flags, default):
 
 
 target_platform = _get_target_platform(
-    os.environ.get("ARCHFLAGS", ""), platform.machine()
+    os.environ.get("VSCMD_ARG_TGT_ARCH", ""), os.environ.get("ARCHFLAGS", ""), platform.machine()
 )
 
 


### PR DESCRIPTION
This enables an arm64 wheel build by adding `ARM64` to the `CIBW_ARCHS` variable for windows builds and ensuring the correct `target_platform` is found when cross-compiling.

#82 