### PR TITLE
ci: switch riscv64 from QEMU to native RISE runner

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,20 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      - name: Set up Python (riscv64)
+        if: matrix.cibw_archs == 'riscv64'
+        run: |
+          PYTHON_DIR=$(ls -d /opt/python-3.1*/bin 2>/dev/null | sort -V | tail -1)
+          if [ -n "$PYTHON_DIR" ]; then
+            echo "$PYTHON_DIR" >> "$GITHUB_PATH"
+            echo "Using Python from $PYTHON_DIR"
+          else
+            echo "No /opt/python found, using system Python"
+          fi
+          python3 --version
+
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        if: matrix.cibw_archs != 'riscv64'
         with:
           enable-cache: false
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
           - os: windows-2022
           - os: windows-11-arm
           - os: macOS-14
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04-riscv
             cibw_archs: "riscv64"
             name_suffix: "-riscv64"
 
@@ -41,12 +41,6 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: false
-
-      - name: Set up QEMU for RISC-V emulation
-        if: matrix.cibw_archs == 'riscv64'
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          platforms: riscv64
 
       # See pyproject.toml for config.
       - uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,27 +38,28 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Set up Python (riscv64)
-        if: matrix.cibw_archs == 'riscv64'
-        run: |
-          PYTHON_DIR=$(ls -d /opt/python-3.1*/bin 2>/dev/null | sort -V | tail -1)
-          if [ -n "$PYTHON_DIR" ]; then
-            echo "$PYTHON_DIR" >> "$GITHUB_PATH"
-            echo "Using Python from $PYTHON_DIR"
-          else
-            echo "No /opt/python found, using system Python"
-          fi
-          python3 --version
-
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         if: matrix.cibw_archs != 'riscv64'
         with:
           enable-cache: false
 
-      # See pyproject.toml for config.
+      # Use the GitHub Action for all platforms except riscv64
       - uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
+        if: matrix.cibw_archs != 'riscv64'
         env:
           CIBW_ARCHS: ${{ matrix.cibw_archs || 'auto' }}
+
+      # On riscv64 native runners, run cibuildwheel via pipx to avoid
+      # the GitHub Action's setup-python call (not available for riscv64)
+      - name: Build wheels (riscv64 native)
+        if: matrix.cibw_archs == 'riscv64'
+        run: |
+          export PATH="$(ls -d /opt/python-3.1*/bin 2>/dev/null | sort -V | tail -1):$PATH"
+          python3 --version
+          python3 -m pip install pipx
+          pipx run cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS: riscv64
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
Switch riscv64 wheel builds from QEMU emulation to a native RISE runner.

Changes:
- Replace `os: ubuntu-22.04` + QEMU setup with `os: ubuntu-24.04-riscv`
- Remove docker/setup-qemu-action step (not needed on native hardware)
- Use `pipx run cibuildwheel` on riscv64 to bypass the GitHub Action's `setup-python` call (not yet available for riscv64)
- Other platforms unchanged

Build time: ~15 minutes on native runner.

Fork validation: https://github.com/gounthar/argon2-cffi-bindings/actions/runs/23667424097

Relates to #105