### PR TITLE
Download artifacts and publish to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,9 +70,9 @@ jobs:
     needs: wheels
     runs-on: ubuntu-latest
     name: Upload release to PyPI
-    environment:
-      name: release-pypi
-      url: https://pypi.org/p/argon2-cffi-bindings
+#    environment:
+#      name: release-pypi
+#      url: https://pypi.org/p/argon2-cffi-bindings
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,4 +61,27 @@ jobs:
         with:
           name: wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
-...
+
+  pypi-publish:
+    if: |
+      github.event.repository.fork == false
+      && github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags')
+    needs: wheels
+    runs-on: ubuntu-latest
+    name: Upload release to PyPI
+    environment:
+      name: release-pypi
+      url: https://pypi.org/p/argon2-cffi-bindings
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - name: List files
+        run: ls -la dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,7 +74,7 @@ jobs:
 #      name: release-pypi
 #      url: https://pypi.org/p/argon2-cffi-bindings
     permissions:
-      id-token: write
+      id-token: write  # necessary for trusted publishing
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Download the wheel artifacts from each job, and upload in a final job.

I've commented out the environment, that can be added later for extra security.

You'll also need to build the sdist somewhere.

Here's a demo where I've temporarily enabled for my fork, and obviously fails to upload to PyPI, but you can see the listed wheels:

https://github.com/hugovk/argon2-cffi-bindings/actions/runs/24304661559

https://github.com/hugovk/argon2-cffi-bindings/actions/runs/24304661559/job/70963996115#step:3:5