### PR TITLE
chore: improve argon2-cffi-bindings maintenance path

### DIFF
--- a/src/_argon2_cffi_bindings/_ffi_build.py
+++ b/src/_argon2_cffi_bindings/_ffi_build.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from cffi import FFI
 
 
-use_system_argon2 = os.environ.get("ARGON2_CFFI_USE_SYSTEM", "0") == "1"
+def _use_system_lib() -> bool:
+    return os.environ.get("ARGON2_CFFI_USE_SYSTEM", "0") == "1"
+
+
+use_system_argon2 = _use_system_lib()
 use_sse2 = os.environ.get("ARGON2_CFFI_USE_SSE2", None)
 windows = platform.system() == "Windows"
 # Free-threaded CPython doesn't support limited API.
@@ -17,7 +21,7 @@ limited_api = not sysconfig.get_config_var("Py_GIL_DISABLED")
 
 
 # Try to detect cross-compilation.
-def _get_target_platform(arch_flags, default):
+def _get_target_platform(arch_flags: str, default: str) -> str:
     flags = [f for f in arch_flags.split(" ") if f.strip() != ""]
     try:
         pos = flags.index("-arch")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,6 +1,21 @@
+import importlib.util
+import sys
+from pathlib import Path
+
 import pytest
 
-from _argon2_cffi_bindings._ffi_build import _get_target_platform
+# Import _ffi_build directly to avoid triggering __init__.py, which requires
+# the compiled _ffi extension to be present.
+_ffi_build_spec = importlib.util.spec_from_file_location(
+    "_ffi_build",
+    Path(__file__).parent.parent / "src" / "_argon2_cffi_bindings" / "_ffi_build.py",
+)
+_ffi_build = importlib.util.module_from_spec(_ffi_build_spec)
+sys.modules["_argon2_cffi_bindings"] = type(sys)("_argon2_cffi_bindings")
+_ffi_build_spec.loader.exec_module(_ffi_build)
+
+_get_target_platform = _ffi_build._get_target_platform
+_use_system_lib = _ffi_build._use_system_lib
 
 
 @pytest.mark.parametrize(
@@ -19,3 +34,26 @@ def test_arch(arch_flags, expected):
     it doesn't find anything.
     """
     assert expected == _get_target_platform(arch_flags, "FOO")
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("1", True),
+        ("0", False),
+        ("", False),
+        ("yes", False),
+        (None, False),
+    ],
+)
+def test_use_system_lib(monkeypatch, env_value, expected):
+    """
+    _use_system_lib returns True only when ARGON2_CFFI_USE_SYSTEM is exactly
+    "1".
+    """
+    if env_value is None:
+        monkeypatch.delenv("ARGON2_CFFI_USE_SYSTEM", raising=False)
+    else:
+        monkeypatch.setenv("ARGON2_CFFI_USE_SYSTEM", env_value)
+
+    assert expected == _use_system_lib()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,14 +1,19 @@
 import importlib.util
 import sys
+
 from pathlib import Path
 
 import pytest
+
 
 # Import _ffi_build directly to avoid triggering __init__.py, which requires
 # the compiled _ffi extension to be present.
 _ffi_build_spec = importlib.util.spec_from_file_location(
     "_ffi_build",
-    Path(__file__).parent.parent / "src" / "_argon2_cffi_bindings" / "_ffi_build.py",
+    Path(__file__).parent.parent
+    / "src"
+    / "_argon2_cffi_bindings"
+    / "_ffi_build.py",
 )
 _ffi_build = importlib.util.module_from_spec(_ffi_build_spec)
 sys.modules["_argon2_cffi_bindings"] = type(sys)("_argon2_cffi_bindings")


### PR DESCRIPTION
Summary:
- Add precise type annotations and a small unit test covering the FFI build helper's edge cases (e.g., environment variable parsing for ARGON2_CFFI_USE_SYSTEM), keeping changes mechanical and self-contained.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.