### PR TITLE
Fix .git_archival.txt: enable export-subst and exclude from sdist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft extras
+exclude .git_archival.txt


### PR DESCRIPTION
## Summary

Two fixes for `.git_archival.txt` version detection:

1. **Add `.gitattributes` with `export-subst`** — without this, `git archive` never substitutes the `$Format:...` placeholders in `.git_archival.txt`, making the file useless for version detection in archives.

2. **Exclude `.git_archival.txt` from sdist** — PyPI sdists are built by setuptools (not `git archive`), so the archival file ships with raw placeholders. When setuptools-scm is installed in the build environment, the unprocessed archival file shadows the valid `PKG-INFO` during fallback version discovery, causing a `LookupError` on platforms without pre-built wheels (e.g. FreeBSD).

## Context

- Reported at: https://github.com/pypa/setuptools-scm/issues/1431
- Affected: any platform building from sdist (no wheels available) where setuptools-scm happens to be installed in the build environment
- The root cause on the setuptools-scm side is also being fixed (fallback discovery will try all candidates instead of only the first), but fixing the archival setup on this side is the correct thing to do regardless.

---

**Closing note:** I picked up the AI policy too late — the commits have LLM co-author tags that violate the project's contribution guidelines. I'll redo this as a clean manual PR tomorrow. Apologies for the noise.