### PR TITLE
Build and test abi3t wheels for Python 3.15+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,91 @@ jobs:
       - run: python -Im pip install tox
       - run: python -Im tox run -e $PYTHON
 
+  abi3t-wheel:
+    name: abi3t cross-test on ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # A cross-section of the platforms we build 3.15 wheels for.
+        # On Linux, tests both libcs and riscv64. Uses the cibuildwheel images.
+        # Windows and macOS use setup-python.
+        include:
+          - name: manylinux_x86_64
+            os: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_34_x86_64@sha256:db817cd4c670f1191d74db6a94a0b115954af78861db7da660de4e93ebf2984c # 2026.08.04-1
+          - name: musllinux_x86_64
+            os: ubuntu-latest
+            container: quay.io/pypa/musllinux_1_2_x86_64@sha256:f130bd3e3aebb39abcdec28a89f987f0d31b52d74bac5852318303698e9a5033 # 2026.08.04-1
+          - name: manylinux_riscv64
+            os: ubuntu-24.04-riscv
+            container: quay.io/pypa/manylinux_2_39_riscv64@sha256:41197d59628c256b0fde14a5dd5bb306e17665c515a8385e43cc72c1da1d7866 # 2026.08.04-1
+          - name: windows-latest
+            os: windows-latest
+          - name: windows-11-arm
+            os: windows-11-arm
+          - name: macos-latest
+            os: macos-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        id: python-ft
+        if: ${{ !matrix.container }}
+        with:
+          python-version: 3.15t
+          allow-prereleases: true
+          cache: pip
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        id: python-gil
+        if: ${{ !matrix.container }}
+        with:
+          python-version: "3.15"
+          allow-prereleases: true
+
+      - name: Pick the interpreters
+        shell: bash
+        env:
+          IN_CONTAINER: ${{ matrix.container && 'yes' || '' }}
+          SETUP_FT: ${{ steps.python-ft.outputs.python-path }}
+          SETUP_GIL: ${{ steps.python-gil.outputs.python-path }}
+        run: |
+          if [[ -n "$IN_CONTAINER" ]]; then
+            echo "FT_PYTHON=/opt/python/cp315-cp315t/bin/python" >>"$GITHUB_ENV"
+            echo "GIL_PYTHON=/opt/python/cp315-cp315/bin/python" >>"$GITHUB_ENV"
+          else
+            echo "FT_PYTHON=$SETUP_FT" >>"$GITHUB_ENV"
+            echo "GIL_PYTHON=$SETUP_GIL" >>"$GITHUB_ENV"
+          fi
+
+      - name: Build a wheel on free-threaded Python
+        shell: bash
+        run: |
+          "$FT_PYTHON" -Im pip install build
+          "$FT_PYTHON" -Im build --wheel
+
+      - name: Ensure the wheel targets the free-threaded stable ABI
+        shell: bash
+        run: |
+          ls dist/
+          test -e dist/*-cp315-abi3.abi3t-*.whl
+
+      - name: Test the wheel on free-threaded Python
+        shell: bash
+        run: |
+          "$FT_PYTHON" -Im pip install dist/*.whl pytest
+          "$FT_PYTHON" -Im pytest
+
+      - name: Test the same wheel on GIL Python
+        shell: bash
+        run: |
+          "$GIL_PYTHON" -Im pip install dist/*.whl pytest
+          "$GIL_PYTHON" -Im pytest
+
   tests-pypy:
     name: Tests against latest PyPy
     runs-on: ubuntu-latest
@@ -187,6 +272,7 @@ jobs:
     needs:
       - build-package
       - tests
+      - abi3t-wheel
       - tests-pypy
       - install-dev
       - system-package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,22 +146,42 @@ jobs:
           "$FT_PYTHON" -Im pip install build
           "$FT_PYTHON" -Im build --wheel
 
-      - name: Ensure the wheel targets the free-threaded stable ABI
+      - name: Select the free-threaded stable ABI wheel
         shell: bash
         run: |
           ls dist/
-          test -e dist/*-cp315-abi3.abi3t-*.whl
+          WHEEL=$(find dist -type f | grep -E '/[^/]+-cp315-abi3\.abi3t-[^/]+\.whl$')
+          test "$(printf '%s\n' "$WHEEL" | wc -l)" -eq 1
+          echo "WHEEL=$WHEEL" >>"$GITHUB_ENV"
+
+      - name: Check the Unix extension suffix
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: |
+          "$FT_PYTHON" -c '
+          import re
+          import sys
+          import zipfile
+
+          with zipfile.ZipFile(sys.argv[1]) as wheel:
+              names = wheel.namelist()
+
+          assert any(
+              re.search(r"\.abi3t(?:-[^/]*)?\.so$", name)
+              for name in names
+          ), names
+          ' "$WHEEL"
 
       - name: Test the wheel on free-threaded Python
         shell: bash
         run: |
-          "$FT_PYTHON" -Im pip install dist/*.whl pytest
+          "$FT_PYTHON" -Im pip install "$WHEEL" pytest
           "$FT_PYTHON" -Im pytest
 
       - name: Test the same wheel on GIL Python
         shell: bash
         run: |
-          "$GIL_PYTHON" -Im pip install dist/*.whl pytest
+          "$GIL_PYTHON" -Im pip install "$WHEEL" pytest
           "$GIL_PYTHON" -Im pytest
 
   tests-pypy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ print(f"Vendoring *Argon2* @ {link}.")
 Vendoring *Argon2* @ [**`f57e61e`**](https://github.com/P-H-C/phc-winner-argon2/commit/f57e61e19229e23c4445b85494dbf7c07de721cb).
 <!-- [[[end]]] -->
 
+### Added
+
+- Free-threaded stable ABI ([PEP 803](https://peps.python.org/pep-0803/)) wheels.
+  Free-threaded CPython 3.15 and later is covered by a single `cp315-abi3.abi3t` wheel that also installs on GIL-enabled CPython 3.15+.
+
+
 ## [26.1.0](https://github.com/hynek/argon2-cffi-bindings/compare/25.1.0...26.1.0) - 2026-08-20
 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The provided CFFI bindings are compiled in API mode.
 Best effort is given to provide binary wheels for as many platforms as possible.
 
 Building from source requires a C compiler and [CMake](https://cmake.org).
+On free-threaded CPython 3.15 and later, it must be CMake 4.4.1 or newer.
 If no suitable CMake is found, one is downloaded automatically as part of the build.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,10 @@ minimum-version = "build-system.requires"
 build-dir = "build/{wheel_tag}"
 # The name-based package auto-detection doesn't find our private package name.
 wheel.packages = ["src/_argon2_cffi_bindings"]
-# Use the CPython 3.10+ stable ABI where supported.
-wheel.py-api = "cp310"
+# On platforms that support binary wheel builds, use the CPython 3.15+
+# free-threaded stable ABI on 3.15+ and the CPython 3.10+ stable ABI on
+# 3.10-3.14.
+wheel.py-api = "cp310.cp315t"
 # Build inputs, not package data.
 wheel.exclude = [
     "_argon2_cffi_bindings/_ffi.cdef.txt",
@@ -72,6 +74,12 @@ wheel.exclude = [
 [[tool.scikit-build.overrides]]
 if.env.PYODIDE = true
 wheel.py-api = ""
+# The free-threaded stable ABI needs CMake 4.4's FindPython; 4.4.0's Windows
+# SABI detection is broken, so require 4.4.1.
+[[tool.scikit-build.overrides]]
+if.abi-flags = "t"
+if.python-version = ">=3.15"
+cmake.version = ">=4.4.1"
 
 
 [[tool.dynamic-metadata]]
@@ -88,8 +96,8 @@ local_scheme = "no-local-version"
 build-frontend = "uv"
 build = [
     "cp310-*",  # abi3 covers CPython 3.10+.
-    "cp314t-*",
-    "cp315t-*",
+    "cp314t-*",  # 3.14 predates the free-threaded stable ABI.
+    "cp315t-*",  # abi3.abi3t covers CPython 3.15+, GIL and free-threaded.
     "pp310-*",
     "pp311-*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ classifiers = [
 ]
 dependencies = [
     "cffi>=1.0.1; python_version < '3.14'",
-    "cffi>=2; python_version >= '3.14'",
+    "cffi>=2; python_version >= '3.14' and python_version < '3.15'",
+    "cffi>=2.1.1; python_version >= '3.15'",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
# Summary

Adds abi3t wheel builds, using the new scikit-build-core build backend.

See https://scikit-build-core.readthedocs.io/en/latest/api/scikit_build_core.settings.html#scikit_build_core.settings.skbuild_model.WheelSettings.py_api.

Most of this is new github actions logic for a check to make sure the single wheel works on both builds. If you're prefer to see this without the extra CI checks, let me know.

@henryiii I'd appreciate you to give this a review pass for the cmake/scikit-build-core details especially.

# Pull Request Checklist

<!--
This list is our brown M&M test:
Ignoring - or even deleting - leads to instant closing of this pull request.
The only exceptions are pure documentation fixes.

Please read our [contribution guide](https://github.com/hynek/argon2-cffi-bindings/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

You may check boxes that don't apply to your pull request to indicate that there isn't anything left to do.
-->

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/argon2-cffi-bindings/blob/main/.github/AI_POLICY.md).
- [x] This pull request is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [x] There's **tests** for all new and changed code.
- [x] Documentation in `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/argon2-cffi-bindings/blob/main/CHANGELOG.md).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
Given the ongoing AI slop wave we need to be strict about policies, but we're happy to help out fellow humans.
-->
